### PR TITLE
fix(LinkBlockToItem): search now in all blocks

### DIFF
--- a/packages/blocks-editor/src/components/LinkBlockToItem/LinkBlockToItem.tsx
+++ b/packages/blocks-editor/src/components/LinkBlockToItem/LinkBlockToItem.tsx
@@ -30,7 +30,11 @@ function List({
     isError: boolean;
     error: any;
     data: any;
-  } = useGroups();
+  } = useGroups(
+    search && search.length > 3 ? {
+      limit: 10000
+    } : undefined
+  );
 
   const results = data.filter(
     ({ slug }: { slug: GroupTypeStore["slug"] }) =>


### PR DESCRIPTION
When we have more than 10 blocks, in the linking of block only show 10 items and the search doesn't permit to find others than the 10 first shown.

![Capture d’écran 2024-03-29 à 11 09 39](https://github.com/thelia/thelia-js-utils/assets/36850920/1635c672-1408-46a8-bc06-31f82483cf02)
