### PR TITLE
fix(useBlockContext): add blocks dependencies in moveBlockTo

### DIFF
--- a/packages/blocks-editor/package.json
+++ b/packages/blocks-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thelia/blocks-editor",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./src/index.tsx",

--- a/packages/blocks-editor/src/hooks/useBlockContext.tsx
+++ b/packages/blocks-editor/src/hooks/useBlockContext.tsx
@@ -38,11 +38,16 @@ export const useBlocksContext = () => {
     }
   }, []);
 
-  const moveBlockTo = useCallback((blockIndex: number, to: number) => {
-    if (typeof to === "number" && to <= blocks.length) {
-      setBlocks((blocks) => [...reorder(blocks, blockIndex, to)]);
-    }
-  }, []);
+  /* We need to have the ‘blocks’ in the dependencies because if we don't,
+     the ‘blocks’ variable in the ‘if’ remains at the initial value of the state. */
+  const moveBlockTo = useCallback(
+    (blockIndex: number, to: number) => {
+      if (typeof to === "number" && to <= blocks.length) {
+        setBlocks((blocks) => [...reorder(blocks, blockIndex, to)]);
+      }
+    },
+    [blocks]
+  );
 
   const resetBlocks = useCallback(() => {
     setBlocks([]);


### PR DESCRIPTION
We need to have the ‘blocks’ in the dependencies because if we don't, the ‘blocks’ variable in the ‘if’ remains at the initial value of the state.